### PR TITLE
8.6.10-php5-rhel-7-r0 (manual) release

### DIFF
--- a/8-php5/rhel-7/Dockerfile
+++ b/8-php5/rhel-7/Dockerfile
@@ -8,7 +8,7 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
 # Install required system packages and dependencies
 RUN install_packages bzip2-libs cyrus-sasl-lib freetype glibc gmp keyutils-libs krb5-libs libcom_err libcurl libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libxml2 libxslt ncurses-libs nspr nss nss-softokn-freebl nss-util openldap openssl-libs pcre postgresql-libs readline xz-libs zlib
 RUN bitnami-pkg unpack nginx-1.14.2-20 --checksum 10e7ce1e441ca0e949b16cb3a3f21338bd61fea074f62ad947aa135d5e824ef0
-RUN bitnami-pkg unpack php-7.1.26-1 --checksum 6010013512da02bfd74bf2c41a95e9b141458175698596a75ef5d51aef54189e
+RUN bitnami-pkg unpack php-5.6.40-0 --checksum 71afd496258065e7d5992e83749ce526fabd6074d15adc39d2dab53a385ef7b8
 RUN bitnami-pkg unpack mysql-client-10.1.38-0 --checksum fdd44abc2ff752b759ded1a7f27e334feed2be427a5850e2d21f2d093f3fee75
 RUN bitnami-pkg unpack drupal-8.6.10-0 --checksum 1fec91cfbe5e71c5e8e446f1501f80524f0d1ad84aa10838f58f0f515043bf6e
 RUN mkdir -p /opt/bitnami/php/logs && chown 1001 /opt/bitnami/php/logs && \

--- a/8-php5/rhel-7/Dockerfile
+++ b/8-php5/rhel-7/Dockerfile
@@ -1,0 +1,52 @@
+FROM registry.rhc4tp.openshift.com/bitnami/rhel-extras-7:latest
+LABEL maintainer "Bitnami <containers@bitnami.com>"
+
+ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
+    BITNAMI_PKG_EXTRA_DIRS="/bitnami/nginx/conf" \
+    HOME="/"
+
+# Install required system packages and dependencies
+RUN install_packages bzip2-libs cyrus-sasl-lib freetype glibc gmp keyutils-libs krb5-libs libcom_err libcurl libgcc libgcrypt libgpg-error libicu libidn libjpeg-turbo libmemcached libpng libselinux libssh2 libstdc++ libxml2 libxslt ncurses-libs nspr nss nss-softokn-freebl nss-util openldap openssl-libs pcre postgresql-libs readline xz-libs zlib
+RUN bitnami-pkg unpack nginx-1.14.2-20 --checksum 10e7ce1e441ca0e949b16cb3a3f21338bd61fea074f62ad947aa135d5e824ef0
+RUN bitnami-pkg unpack php-7.1.26-1 --checksum 6010013512da02bfd74bf2c41a95e9b141458175698596a75ef5d51aef54189e
+RUN bitnami-pkg unpack mysql-client-10.1.38-0 --checksum fdd44abc2ff752b759ded1a7f27e334feed2be427a5850e2d21f2d093f3fee75
+RUN bitnami-pkg unpack drupal-8.6.10-0 --checksum 1fec91cfbe5e71c5e8e446f1501f80524f0d1ad84aa10838f58f0f515043bf6e
+RUN mkdir -p /opt/bitnami/php/logs && chown 1001 /opt/bitnami/php/logs && \
+    mkdir -p /opt/bitnami/php/tmp && chown 1001 /opt/bitnami/php/tmp && \
+    ln -sf /opt/bitnami/php/etc /opt/bitnami/php/conf
+RUN ln -sf /dev/stdout /opt/bitnami/nginx/logs/access.log
+RUN ln -sf /dev/stderr /opt/bitnami/nginx/logs/error.log
+
+COPY rootfs /
+ENV ALLOW_EMPTY_PASSWORD="no" \
+    BITNAMI_APP_NAME="drupal-nginx" \
+    BITNAMI_IMAGE_VERSION="8.6.10-rhel-7-r1" \
+    DRUPAL_DATABASE_NAME="bitnami_drupal" \
+    DRUPAL_DATABASE_PASSWORD="" \
+    DRUPAL_DATABASE_USER="bn_drupal" \
+    DRUPAL_EMAIL="user@example.com" \
+    DRUPAL_HTTPS_PORT="8443" \
+    DRUPAL_HTTP_PORT="8080" \
+    DRUPAL_PASSWORD="bitnami" \
+    DRUPAL_PROFILE="standard" \
+    DRUPAL_USERNAME="user" \
+    MARIADB_HOST="mariadb" \
+    MARIADB_PORT_NUMBER="3306" \
+    MARIADB_ROOT_PASSWORD="" \
+    MARIADB_ROOT_USER="root" \
+    MYSQL_CLIENT_CREATE_DATABASE_NAME="" \
+    MYSQL_CLIENT_CREATE_DATABASE_PASSWORD="" \
+    MYSQL_CLIENT_CREATE_DATABASE_PRIVILEGES="ALL" \
+    MYSQL_CLIENT_CREATE_DATABASE_USER="" \
+    NAMI_PREFIX="/.nami" \
+    NGINX_DAEMON_GROUP="nginx" \
+    NGINX_DAEMON_USER="nginx" \
+    NGINX_HTTPS_PORT_NUMBER="8443" \
+    NGINX_HTTP_PORT_NUMBER="8080" \
+    PATH="/opt/bitnami/nginx/sbin:/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/mysql/bin:/opt/bitnami/drupal/vendor/bin:$PATH"
+
+EXPOSE 8080
+
+USER 1001
+ENTRYPOINT [ "/app-entrypoint.sh" ]
+CMD [ "./run.sh" ]

--- a/8-php5/rhel-7/Dockerfile
+++ b/8-php5/rhel-7/Dockerfile
@@ -20,7 +20,7 @@ RUN ln -sf /dev/stderr /opt/bitnami/nginx/logs/error.log
 COPY rootfs /
 ENV ALLOW_EMPTY_PASSWORD="no" \
     BITNAMI_APP_NAME="drupal-nginx" \
-    BITNAMI_IMAGE_VERSION="8.6.10-rhel-7-r1" \
+    BITNAMI_IMAGE_VERSION="8.6.10-php5-rhel-7-r0" \
     DRUPAL_DATABASE_NAME="bitnami_drupal" \
     DRUPAL_DATABASE_PASSWORD="" \
     DRUPAL_DATABASE_USER="bn_drupal" \
@@ -49,4 +49,4 @@ EXPOSE 8080
 
 USER 1001
 ENTRYPOINT [ "/app-entrypoint.sh" ]
-CMD [ "./run.sh" ]
+CMD [ "/run.sh" ]

--- a/8-php5/rhel-7/docker-compose.yml
+++ b/8-php5/rhel-7/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - 'mariadb_data:/bitnami'
   drupal:
-    image: 'bitnami/drupal-nginx:8-rhel-7'
+    image: 'bitnami/drupal-nginx:8-php5-rhel-7'
     environment:
       - MARIADB_HOST=mariadb
       - MARIADB_PORT_NUMBER=3306

--- a/8-php5/rhel-7/docker-compose.yml
+++ b/8-php5/rhel-7/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '2'
+
+services:
+  mariadb:
+    image: 'bitnami/mariadb:latest'
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MARIADB_USER=bn_drupal
+      - MARIADB_DATABASE=bitnami_drupal
+    volumes:
+      - 'mariadb_data:/bitnami'
+  drupal:
+    image: 'bitnami/drupal-nginx:8-rhel-7'
+    environment:
+      - MARIADB_HOST=mariadb
+      - MARIADB_PORT_NUMBER=3306
+      - DRUPAL_HTTP_PORT=8080
+      - DRUPAL_HTTPS_PORT=8443
+      - DRUPAL_DATABASE_USER=bn_drupal
+      - DRUPAL_DATABASE_NAME=bitnami_drupal
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - '80:8080'
+      - '443:8443'
+    volumes:
+      - 'drupal_data:/bitnami/drupal'
+      - './drupal-vhosts.conf:/bitnami/nginx/conf/vhosts/drupal-vhosts.conf'
+    depends_on:
+      - mariadb
+volumes:
+  mariadb_data:
+    driver: local
+  drupal_data:
+    driver: local

--- a/8-php5/rhel-7/drupal-vhosts.conf
+++ b/8-php5/rhel-7/drupal-vhosts.conf
@@ -1,0 +1,85 @@
+server {
+  listen 0.0.0.0:8080;
+  server_name myapp.example.com;
+
+  root /opt/bitnami/drupal;
+
+  location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+  }
+
+  location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+  }
+
+  location ~ ^/sites/.*/private/ {
+    return 403;
+  }
+
+  # Block access to scripts in site files directory
+  location ~ ^/sites/[^/]+/files/.*\.php$ {
+    deny all;
+  }
+
+  # Allow "Well-Known URIs" as per RFC 5785
+  location ~* ^/.well-known/ {
+    allow all;
+  }
+
+  # Block access to "hidden" files and directories whose names begin with a
+  # period. This includes directories used by version control systems such
+  # as Subversion or Git to store control files.
+  location ~ (^|/)\. {
+    return 403;
+  }
+
+  location / {
+    try_files $uri /index.php?$query_string;
+  }
+
+  location @rewrite {
+    rewrite ^/(.*)$ /index.php?q=$1;
+  }
+
+  # Don't allow direct access to PHP files in the vendor directory.
+  location ~ /vendor/.*\.php$ {
+    deny all;
+    return 404;
+  }
+
+  # The laxer rule will continue to work if Drupal uses this new URL
+  # pattern with front controllers other than update.php in a future
+  # release.
+  location ~ \.php(/|$) {
+    fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+    include fastcgi_params;
+    # Block httpoxy attacks. See https://httpoxy.org/.
+    fastcgi_param HTTP_PROXY "";
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param PATH_INFO $fastcgi_path_info;
+    fastcgi_param QUERY_STRING $query_string;
+    fastcgi_intercept_errors on;
+    # PHP 7 socket location.
+    fastcgi_pass localhost:9000;
+  }
+
+  # Fighting with Styles? This little gem is amazing.
+  location ~ ^/sites/.*/files/styles/ {
+    try_files $uri @rewrite;
+  }
+
+  # Handle private files through Drupal. Private file's path can come
+  # with a language prefix.
+  location ~ ^(/[a-z\-]+)?/system/files/ {
+    try_files $uri /index.php?$query_string;
+  }
+
+  location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+    try_files $uri @rewrite;
+    expires max;
+    log_not_found off;
+  }
+}

--- a/8-php5/rhel-7/rootfs/app-entrypoint.sh
+++ b/8-php5/rhel-7/rootfs/app-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+. /opt/bitnami/base/functions
+. /opt/bitnami/base/helpers
+
+print_welcome_page
+
+if [[ "$1" == "nami" && "$2" == "start" ]] || [[ "$1" == "./run.sh" ]]; then
+  . /init.sh
+  nami_initialize nginx mysql-client drupal
+  info "Starting drupal... "
+fi
+
+exec tini -- "$@"

--- a/8-php5/rhel-7/rootfs/drupal-inputs.json
+++ b/8-php5/rhel-7/rootfs/drupal-inputs.json
@@ -1,0 +1,13 @@
+{
+  "databaseName": "{{$global.env.DRUPAL_DATABASE_NAME}}",
+  "databasePassword": "{{$global.env.DRUPAL_DATABASE_PASSWORD}}",
+  "databaseServerHost": "{{$global.env.MARIADB_HOST}}",
+  "databaseServerPort": "{{$global.env.MARIADB_PORT_NUMBER}}",
+  "databaseUser": "{{$global.env.DRUPAL_DATABASE_USER}}",
+  "email": "{{$global.env.DRUPAL_EMAIL}}",
+  "httpPort": "{{$global.env.DRUPAL_HTTP_PORT}}",
+  "httpsPort": "{{$global.env.DRUPAL_HTTPS_PORT}}",
+  "installationProfile": "{{$global.env.DRUPAL_PROFILE}}",
+  "password": "{{$global.env.DRUPAL_PASSWORD}}",
+  "username": "{{$global.env.DRUPAL_USERNAME}}"
+}

--- a/8-php5/rhel-7/rootfs/init.sh
+++ b/8-php5/rhel-7/rootfs/init.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+##
+## @brief     Helper function to show an error when a password is empty and exit
+## param $1   Input name
+##
+empty_password_error() {
+  error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
+  exit 1
+}
+
+##
+## @brief     Helper function to show a warning when the ALLOW_EMPTY_PASSWORD flag is enabled
+##
+empty_password_enabled_warn() {
+  warn "You set the environment variable ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD}. For safety reasons, do not use this flag in a production environment."
+}
+
+# Validate passwords
+if [[ "$ALLOW_EMPTY_PASSWORD" =~ ^(yes|Yes|YES)$ ]]; then
+  empty_password_enabled_warn
+else
+  # Database creation by MySQL client
+  if [[ -n "$MYSQL_CLIENT_CREATE_DATABASE_USER" && -z "$MYSQL_CLIENT_CREATE_DATABASE_PASSWORD" ]]; then
+    empty_password_error MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
+  fi
+  # Drupal database
+  if [[ -z "$DRUPAL_DATABASE_PASSWORD" ]]; then
+    empty_password_error DRUPAL_DATABASE_PASSWORD
+  fi
+fi

--- a/8-php5/rhel-7/rootfs/mysql-client-inputs.json
+++ b/8-php5/rhel-7/rootfs/mysql-client-inputs.json
@@ -1,0 +1,11 @@
+{
+  "allowEmptyPassword": "{{$global.env.ALLOW_EMPTY_PASSWORD}}",
+  "createDatabaseName": "{{$global.env.MYSQL_CLIENT_CREATE_DATABASE_NAME}}",
+  "createDatabasePassword": "{{$global.env.MYSQL_CLIENT_CREATE_DATABASE_PASSWORD}}",
+  "createDatabasePrivileges": "{{$global.env.MYSQL_CLIENT_CREATE_DATABASE_PRIVILEGES}}",
+  "createDatabaseUser": "{{$global.env.MYSQL_CLIENT_CREATE_DATABASE_USER}}",
+  "host": "{{$global.env.MARIADB_HOST}}",
+  "port": "{{$global.env.MARIADB_PORT_NUMBER}}",
+  "rootPassword": "{{$global.env.MARIADB_ROOT_PASSWORD}}",
+  "rootUser": "{{$global.env.MARIADB_ROOT_USER}}"
+}

--- a/8-php5/rhel-7/rootfs/nginx-inputs.json
+++ b/8-php5/rhel-7/rootfs/nginx-inputs.json
@@ -1,0 +1,6 @@
+{
+  "httpPort": "{{$global.env.NGINX_HTTP_PORT_NUMBER}}",
+  "httpsPort": "{{$global.env.NGINX_HTTPS_PORT_NUMBER}}",
+  "systemGroup": "{{$global.env.NGINX_DAEMON_GROUP}}",
+  "systemUser": "{{$global.env.NGINX_DAEMON_USER}}"
+}

--- a/8-php5/rhel-7/rootfs/run.sh
+++ b/8-php5/rhel-7/rootfs/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+. /opt/bitnami/base/functions
+. /opt/bitnami/base/helpers
+
+NGINX_INSTALLDIR="/opt/bitnami/nginx"
+NGINX_CONF_DIR="${NGINX_INSTALLDIR}/conf"
+PHP_INSTALLDIR="/opt/bitnami/php"
+PHP_CONF_DIR="${PHP_INSTALLDIR}/etc"
+PHP_TEMP_DIR="${PHP_INSTALLDIR}/tmp"
+
+_forwardTerm () {
+ echo "Caugth signal SIGTERM, passing it to child processes..."
+ cpids=$(pgrep -P $$ | xargs)
+ kill -15 "$cpids" 2> /dev/null
+ wait
+ exit $?
+}
+
+trap _forwardTerm TERM
+
+info "Starting php-fpm..."
+php-fpm --pid "${PHP_TEMP_DIR}/php5-fpm.pid" --fpm-config "${PHP_CONF_DIR}/php-fpm.conf" --prefix "${PHP_INSTALLDIR}" -c "${PHP_CONF_DIR}/php.ini" &
+
+info "Starting nginx..."
+nginx -c "${NGINX_CONF_DIR}/nginx.conf" -g "daemon off;" &
+wait


### PR DESCRIPTION
Update Drupal to 8.6.10 and its components

In https://github.com/bitnami/bitnami-docker-drupal/pull/103 we only update the components, but in this case, the folder didn't exist.
I copied the files from Drupal with php7 in the first commit https://github.com/bitnami/bitnami-docker-drupal-nginx/commit/f651bd4259fda575da124ca4a0dd92fbb2b37ce8 and I updated the version in the second one https://github.com/bitnami/bitnami-docker-drupal-nginx/commit/c76257d1954ef24facdfd7a9ad766afb7955a314